### PR TITLE
Add JIRA integration and fix template path references

### DIFF
--- a/.ai/1_templates/bootstrap-template.md
+++ b/.ai/1_templates/bootstrap-template.md
@@ -13,7 +13,7 @@
    → If unclear: Provide options based on common patterns
 3. Determine architecture style
    → Ask: "What architecture pattern?" (hexagonal, clean, layered, microservices, CLI tool)
-   → Load appropriate tech stack doc from .ai/3_tech_stacks/
+   → Load appropriate tech stack doc from ~/.ai/3_tech_stacks/ (from home directory)
 4. Determine build tooling
    → Ask: "What build tool?" (Maven/Gradle, npm/pnpm, Make, Poetry)
    → Ask: "Multi-module or monorepo?"

--- a/.ai/1_templates/plan-template.md
+++ b/.ai/1_templates/plan-template.md
@@ -1,7 +1,8 @@
 # Implementation Plan: [FEATURE]
 
-**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
-**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+**JIRA Task**: [JIRA-TASK-NUMBER or N/A]
+**Branch**: `[###-feature-name]` or `[feature/JIRA-TASK-NUMBER]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[branch-name]/spec.md`
 
 ## Execution Flow (/plan command scope)
 ```
@@ -52,7 +53,7 @@
 
 ### Documentation (this feature)
 ```
-specs/[###-feature]/
+specs/[branch-name]/     # Either [###-feature] or [feature-JIRA-TASK-NUMBER]
 ├── plan.md              # This file (/plan command output)
 ├── research.md          # Phase 0 output (/plan command)
 ├── data-model.md        # Phase 1 output (/plan command)
@@ -152,7 +153,7 @@ directories captured above]
 
 5. **Update AGENTS.md at project root** (incremental, O(1) operation):
    - Check if `AGENTS.md` exists at project root:
-     - **If NO**: Load `.ai/1_templates/agents-template.md` and create initial AGENTS.md
+     - **If NO**: Load `~/.ai/1_templates/agents-template.md` (from home directory) and create initial AGENTS.md
      - **If YES**: Read current `AGENTS.md` for updating
    - Extract technology stack from Technical Context above:
      - Language/Version + Primary Dependencies = tech stack entry
@@ -173,7 +174,7 @@ directories captured above]
 *This section describes what the /tasks command will do - DO NOT execute during /plan*
 
 **Task Generation Strategy**:
-- Load `.ai/1_templates/tasks-template.md` as base
+- Load `~/.ai/1_templates/tasks-template.md` (from home directory) as base
 - Generate tasks from Phase 1 design docs (contracts, data model, quickstart)
 - Each contract → contract test task [P]
 - Each entity → model creation task [P]

--- a/.ai/1_templates/spec-template.md
+++ b/.ai/1_templates/spec-template.md
@@ -1,6 +1,7 @@
 # Feature Specification: [FEATURE NAME]
 
-**Feature Branch**: `[###-feature-name]`
+**JIRA Task**: [JIRA-TASK-NUMBER or N/A]
+**Feature Branch**: `[###-feature-name]` or `[feature/JIRA-TASK-NUMBER]`
 **Created**: [DATE]
 **Status**: Draft
 **Input**: User description: "$ARGUMENTS"

--- a/.ai/1_templates/tasks-template.md
+++ b/.ai/1_templates/tasks-template.md
@@ -1,7 +1,10 @@
 # Tasks: [FEATURE NAME]
 
-**Input**: Design documents from `/specs/[###-feature-name]/`
+**JIRA Task**: [JIRA-TASK-NUMBER or N/A]
+**Input**: Design documents from `/specs/[branch-name]/`
 **Prerequisites**: plan.md (required), research.md, data-model.md, contracts/
+
+**Note**: Task IDs (T001, T002, etc.) are independent of JIRA task numbers. JIRA task number applies to the feature as a whole, not individual implementation tasks.
 
 ## Execution Flow (main)
 ```

--- a/.ai/2_commands/bootstrap.md
+++ b/.ai/2_commands/bootstrap.md
@@ -12,7 +12,7 @@ The text the user typed after `/bootstrap` in the triggering message **is** the 
 
 Given that project description, do this:
 
-1. Load `.ai/1_templates/bootstrap-template.md` to understand the interactive bootstrap process.
+1. Load `~/.ai/1_templates/bootstrap-template.md` (from home directory) to understand the interactive bootstrap process.
 
 2. Check if `constitution.md` exists at project root:
    - **If YES**: Read the constitution to understand constitutional requirements

--- a/.ai/2_commands/constitution.md
+++ b/.ai/2_commands/constitution.md
@@ -13,7 +13,7 @@ You are creating or updating the project constitution at `constitution.md`.
 Follow this execution flow:
 
 1. Check if `constitution.md` exists at project root:
-   - **If NO**: Load `.ai/1_templates/constitution-template.md` as the starting template
+   - **If NO**: Load `~/.ai/1_templates/constitution-template.md` (from home directory) as the starting template
    - **If YES**: Load the existing `constitution.md` from project root
 
 2. Identify placeholder tokens:
@@ -38,10 +38,10 @@ Follow this execution flow:
    - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
 
 5. Consistency propagation checklist (convert prior checklist into active validations):
-   - Read `.ai/1_templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
-   - Read `.ai/1_templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
-   - Read `.ai/1_templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
-   - Read each command file in `.ai/3_commands/*.md` (including this one) to verify no outdated references remain when generic guidance is required.
+   - Read `~/.ai/1_templates/plan-template.md` (from home directory) and ensure any "Constitution Check" or rules align with updated principles.
+   - Read `~/.ai/1_templates/spec-template.md` (from home directory) for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read `~/.ai/1_templates/tasks-template.md` (from home directory) and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Read each command file in `~/.ai/2_commands/*.md` (including this one) to verify no outdated references remain when generic guidance is required.
    - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
 
 6. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):

--- a/.ai/2_commands/plan.md
+++ b/.ai/2_commands/plan.md
@@ -25,7 +25,7 @@ Given the implementation details provided as an argument, do this:
 3. Read the constitution at `constitution.md` to understand constitutional requirements.
 
 4. Execute the implementation plan template:
-   - Load `.ai/1_templates/plan-template.md` as reference
+   - Load `~/.ai/1_templates/plan-template.md` (from home directory) as reference
    - Copy template to IMPL_PLAN path
    - Set Input path to FEATURE_SPEC
    - Run the Execution Flow (main) function steps 1-9

--- a/.ai/2_commands/specify.md
+++ b/.ai/2_commands/specify.md
@@ -12,15 +12,25 @@ The text the user typed after `/specify` in the triggering message **is** the fe
 
 Given that feature description, do this:
 
-1. Determine the next feature number and branch name:
-   - List all directories in `specs/` to find highest number (e.g., 001, 002, 003)
-   - Increment by 1 to get new feature number (e.g., if 003 exists, new is 004)
-   - Create branch name from number + feature description slug (e.g., `004-user-notifications`)
-   - Create feature directory: `specs/[branch-name]/`
-   - Create git branch with same name
+1. Parse JIRA task number (if present) and determine branch naming strategy:
+   - Check if feature description contains a JIRA task ID (e.g., PROJ-123, ABC-456)
+   - If JIRA task found:
+     - Extract JIRA task number
+     - Use enterprise branch format: `feature/JIRA-TASK-NUMBER` (e.g., `feature/PROJ-123`)
+     - Create feature directory: `specs/feature-JIRA-TASK-NUMBER/` (e.g., `specs/feature-PROJ-123/`)
+   - If NO JIRA task found:
+     - List all directories in `specs/` to find highest number (e.g., 001, 002, 003)
+     - Increment by 1 to get new feature number (e.g., if 003 exists, new is 004)
+     - Create branch name from number + feature description slug (e.g., `004-user-notifications`)
+     - Create feature directory: `specs/[branch-name]/` (e.g., `specs/004-user-notifications/`)
+   - Create git branch with the determined branch name
 
-2. Load `.ai/1_templates/spec-template.md` to understand required sections.
+2. Load `~/.ai/1_templates/spec-template.md` (from home directory) to understand required sections.
 
-3. Write the specification to `specs/[branch-name]/spec.md` using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+3. Write the specification to `specs/[branch-name]/spec.md` using the template structure:
+   - If JIRA task found: Set **JIRA Task** field to the JIRA task number, **Feature Branch** to `feature/JIRA-TASK-NUMBER`
+   - If NO JIRA task: Set **JIRA Task** field to "N/A", **Feature Branch** to `###-feature-name` format
+   - Replace other placeholders with concrete details derived from the feature description (arguments)
+   - Preserve section order and headings
 
-4. Report completion with branch name, spec file path, and readiness for the next phase.
+4. Report completion with branch name, spec file path, JIRA task number (if applicable), and readiness for the next phase.

--- a/.ai/2_commands/specify.md
+++ b/.ai/2_commands/specify.md
@@ -10,10 +10,15 @@ $ARGUMENTS
 
 The text the user typed after `/specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `{ARGS}` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
 
+**Branch & Directory Naming:**
+- With JIRA (e.g., `PROJ-123`): Branch = `feature/PROJ-123`, Directory = `specs/feature-PROJ-123/`
+- Without JIRA: Branch = `001-feature-name`, Directory = `specs/001-feature-name/`
+- Note: Branch and directory names always match for consistency
+
 Given that feature description, do this:
 
 1. Parse JIRA task number (if present) and determine branch naming strategy:
-   - Check if feature description contains a JIRA task ID (e.g., PROJ-123, ABC-456)
+   - Check if feature description contains a JIRA task ID using pattern: `[A-Z]+-[0-9]+` (e.g., PROJ-123, ABC-456, FEATURE-789)
    - If JIRA task found:
      - Extract JIRA task number
      - Use enterprise branch format: `feature/JIRA-TASK-NUMBER` (e.g., `feature/PROJ-123`)

--- a/.ai/2_commands/tasks.md
+++ b/.ai/2_commands/tasks.md
@@ -27,7 +27,7 @@ $ARGUMENTS
    - Generate tasks based on what's available
 
 3. Generate tasks following the template:
-   - Use `.ai/1_templates/tasks-template.md` as the base
+   - Use `~/.ai/1_templates/tasks-template.md` (from home directory) as the base
    - Replace example tasks with actual tasks based on:
      * **Setup tasks**: Project init, dependencies, linting
      * **Test tasks [P]**: One per contract, one per integration scenario

--- a/.ai/2_commands/workflows/implement.md
+++ b/.ai/2_commands/workflows/implement.md
@@ -51,8 +51,8 @@ $ARGUMENTS
    - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file
    - **Git commits**: Include JIRA task number in commit messages if feature has one:
      - Read JIRA Task field from spec.md to determine if JIRA task exists
-     - With JIRA: `feat(JIRA-TASK-NUMBER): task description`
-     - Without JIRA: `feat: task description` or use feature number if applicable
+     - With JIRA: `feat(JIRA-TASK-NUMBER): task description\n\nSee specs/feature-JIRA-TASK-NUMBER/spec.md`
+     - Without JIRA: `feat(NNN): task description\n\nSee specs/NNN-feature/spec.md`
 
 7. Completion validation:
    - Verify all required tasks are completed

--- a/.ai/2_commands/workflows/implement.md
+++ b/.ai/2_commands/workflows/implement.md
@@ -48,7 +48,11 @@ $ARGUMENTS
    - For parallel tasks [P], continue with successful tasks, report failed ones
    - Provide clear error messages with context for debugging
    - Suggest next steps if implementation cannot proceed
-   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file
+   - **Git commits**: Include JIRA task number in commit messages if feature has one:
+     - Read JIRA Task field from spec.md to determine if JIRA task exists
+     - With JIRA: `feat(JIRA-TASK-NUMBER): task description`
+     - Without JIRA: `feat: task description` or use feature number if applicable
 
 7. Completion validation:
    - Verify all required tasks are completed

--- a/.ai/2_commands/workflows/spec-driven.md
+++ b/.ai/2_commands/workflows/spec-driven.md
@@ -24,7 +24,7 @@ Feature to implement using spec-driven approach: $ARGUMENTS
 
 **Manual Specification**:
 1. Create feature directory: `specs/NNN-feature-name/`
-2. Copy spec template from `.ai/1_templates/spec-template.md`
+2. Copy spec template from `~/.ai/1_templates/spec-template.md` (from home directory)
 3. Fill in sections: Overview, Requirements, Acceptance Criteria, Success Metrics
 4. Review for completeness and clarity
 
@@ -129,7 +129,9 @@ Use task template format with checkboxes for tracking."
 During BUILD phase:
 - Mark tasks as 🟢 (completed), 🟡 (in progress), 🔴 (blocked)
 - Update tasks.md after each completed task
-- Commit code with spec reference: `feat(NNN): description\n\nSee specs/NNN-feature/spec.md`
+- Commit code with spec reference:
+  - With JIRA: `feat(JIRA-TASK-NUMBER): description\n\nSee specs/feature-JIRA-TASK-NUMBER/spec.md`
+  - Without JIRA: `feat(NNN): description\n\nSee specs/NNN-feature/spec.md`
 - Run tests continuously to maintain green state
 
 ### Validation Checkpoint: BUILD Phase
@@ -198,6 +200,15 @@ After successful verification:
 2. **Commit Final Changes**
    ```
    git add .
+   # If JIRA task exists:
+   git commit -m "feat(JIRA-TASK-NUMBER): Feature description
+
+   Implements specs/feature-JIRA-TASK-NUMBER/spec.md
+   All acceptance criteria validated.
+
+   Co-Authored-By: Claude <noreply@anthropic.com>"
+
+   # If no JIRA task (numbered feature):
    git commit -m "feat(NNN): Feature description
 
    Implements specs/NNN-feature/spec.md

--- a/.ai/2_commands/workflows/spec-review.md
+++ b/.ai/2_commands/workflows/spec-review.md
@@ -20,7 +20,7 @@ Wait for user confirmation before proceeding.
 
 Given the review scope, do this:
 
-1. Load `.ai/1_templates/review-template.md` to understand the review process and report structure.
+1. Load `~/.ai/1_templates/review-template.md` (from home directory) to understand the review process and report structure.
 
 2. Determine feature context based on scope:
    - If user provided feature path (e.g., `specs/003-user-auth`), use it

--- a/.ai/3_tech_stacks/tech-stack-ai.md
+++ b/.ai/3_tech_stacks/tech-stack-ai.md
@@ -218,7 +218,7 @@ Each `tech-stack-{name}.md` file contains:
 - `tech-stack-ai.md`: AI configuration systems (this file)
 
 ### Adding New Tech Stacks
-1. Create `.ai/3_tech_stacks/tech-stack-{name}.md`
+1. Create `~/.ai/3_tech_stacks/tech-stack-{name}.md` (in home directory dotfiles)
 2. Document architecture, testing, conventions
 3. Provide code examples and patterns
 4. Add to project's `constitution.md`: `tech_stack: {name}`
@@ -305,6 +305,6 @@ Each category folder must have README.md:
 - **Gather feedback**: Improve based on actual usage
 
 ## References
-- Spec-Driven Development: `.ai/2_commands/workflows/spec-driven.md`
-- Agent Categories: `.ai/4_agents/README.md`
-- Constitution Command: `.ai/2_commands/constitution.md` (Bootstrap project constitution)
+- Spec-Driven Development: `~/.ai/2_commands/workflows/spec-driven.md`
+- Agent Categories: `~/.ai/4_agents/README.md`
+- Constitution Command: `~/.ai/2_commands/constitution.md` (Bootstrap project constitution)

--- a/README.md
+++ b/README.md
@@ -246,6 +246,49 @@ After running `install.sh`:
    ls -la ~/.ai ~/.claude ~/.copilot ~/.gemini ~/.cursor
    ```
 
+## Path Structure & Usage
+
+### Understanding `.ai/` vs `~/.ai/`
+
+This repository uses a **symlink-based setup** to make templates accessible from any project:
+
+**Setup:**
+```bash
+~/Projects/dotfiles/.ai/    # Source (git-tracked repository)
+~/.ai/ → ~/Projects/dotfiles/.ai/    # Symlink (global access)
+```
+
+**When to use which path:**
+
+| Context | Path | Example | Reason |
+|---------|------|---------|--------|
+| **Commands reference templates** | `~/.ai/` | `~/.ai/1_templates/spec-template.md` | Works from any project directory |
+| **Project-local specs** | `.ai/` or `specs/` | `specs/001-feature/spec.md` | Project-specific artifacts |
+| **Documentation/examples** | Either | Both work | Preference for clarity |
+
+**Key principle:**
+- **Global templates & commands**: Use `~/.ai/` (from dotfiles, shared across all projects)
+- **Project-specific files**: Use project root paths (specs, constitution.md, AGENTS.md)
+
+**Example workflow:**
+```bash
+# In any project directory
+cd ~/Projects/my-app/
+
+# Command loads template from home
+/specify PROJ-123 Add user authentication
+# → Loads: ~/.ai/1_templates/spec-template.md (global)
+# → Creates: ./specs/feature-PROJ-123/spec.md (local)
+
+# Commands reference global paths
+~/.ai/2_commands/plan.md references ~/.ai/1_templates/plan-template.md
+
+# Projects create local artifacts
+./specs/001-feature/spec.md
+./constitution.md
+./AGENTS.md
+```
+
 ## Using with Different AI Tools
 
 ### Claude Code


### PR DESCRIPTION
- Support JIRA task numbers in spec-driven workflow (e.g., PROJ-123)
- Auto-detect JIRA IDs and create feature/JIRA-XXX branches
- Include JIRA numbers in commit messages when present
- Fix all template references to use ~/.ai/ instead of .ai/
- Update 13 files across templates, commands, and workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)